### PR TITLE
added iOS notification observer for the floating keyboard

### DIFF
--- a/flutter_keyboard_visibility_temp_fork/ios/Classes/FlutterKeyboardVisibilityPlugin.m
+++ b/flutter_keyboard_visibility_temp_fork/ios/Classes/FlutterKeyboardVisibilityPlugin.m
@@ -13,6 +13,7 @@
 @property (copy, nonatomic) FlutterEventSink flutterEventSink;
 @property (assign, nonatomic) BOOL flutterEventListening;
 @property (assign, nonatomic) BOOL isVisible;
+@property (assign, nonatomic) BOOL isFloating;
 
 @end
 
@@ -36,8 +37,26 @@
     [center addObserver:self selector:@selector(didShow) name:UIKeyboardDidShowNotification object:nil];
     [center addObserver:self selector:@selector(willShow) name:UIKeyboardWillShowNotification object:nil];
 	[center addObserver:self selector:@selector(didHide) name:UIKeyboardWillHideNotification object:nil];
+    [center addObserver:self selector:@selector(didChangeFrame:) name:UIKeyboardDidChangeFrameNotification object:nil];
 
     return self;
+}
+
+- (void)didChangeFrame:(NSNotification *)notification
+{
+    NSValue *keyboardFrameValue = [notification.userInfo objectForKey:UIKeyboardFrameEndUserInfoKey];
+    CGRect keyboardFrame = [keyboardFrameValue CGRectValue];
+    CGRect screenBounds = [UIScreen mainScreen].bounds;
+
+    if (keyboardFrame.size.width > 0 &&
+        keyboardFrame.size.width < screenBounds.size.width &&
+        keyboardFrame.origin.y < screenBounds.size.height) {
+        self.isFloating = YES;
+        [self didShow];
+    } else if (self.isFloating)  {
+        self.isFloating = NO;
+        [self didHide];
+    }
 }
 
 - (void)didShow

--- a/flutter_keyboard_visibility_temp_fork/lib/src/keyboard_visibility_handler.dart
+++ b/flutter_keyboard_visibility_temp_fork/lib/src/keyboard_visibility_handler.dart
@@ -34,7 +34,7 @@ class KeyboardVisibilityHandler {
   /// reported exclusively by the `isVisible` getter.
   static bool? _testIsVisible;
 
-  /// Debounce timer - if keyboard is bouncing - wait 150 ms to make sure there are no
+  /// Debounce timer - if keyboard is bouncing - wait 250 ms to make sure there are no
   /// more changes. This happens when switching from keyboard to voice typing on Android.
   static Timer? _debounce;
 
@@ -51,7 +51,7 @@ class KeyboardVisibilityHandler {
     if (_debounce?.isActive ?? false) _debounce?.cancel();
     // report keyboard visible quickly, report keyboard not visible after longer delay
     // in case the keyboard is just switching modes
-    _debounce = Timer(Duration(milliseconds: newValue ? 25 : 150), () {
+    _debounce = Timer(Duration(milliseconds: newValue ? 25 : 250), () {
       _testIsVisible = newValue;
 
       // Don't report the same value multiple times

--- a/flutter_keyboard_visibility_temp_fork/lib/src/keyboard_visibility_handler.dart
+++ b/flutter_keyboard_visibility_temp_fork/lib/src/keyboard_visibility_handler.dart
@@ -34,6 +34,10 @@ class KeyboardVisibilityHandler {
   /// reported exclusively by the `isVisible` getter.
   static bool? _testIsVisible;
 
+  /// Debounce timer - if keyboard is bouncing - wait 150 ms to make sure there are no
+  /// more changes. This happens when switching from keyboard to voice typing on Android.
+  static Timer? _debounce;
+
   /// Forces `KeyboardVisibilityHandler` to report `isKeyboardVisible`
   /// for testing purposes.
   ///
@@ -44,14 +48,19 @@ class KeyboardVisibilityHandler {
   }
 
   static void _updateValue(bool newValue) {
-    _testIsVisible = newValue;
+    if (_debounce?.isActive ?? false) _debounce?.cancel();
+    // report keyboard visible quickly, report keyboard not visible after longer delay
+    // in case the keyboard is just switching modes
+    _debounce = Timer(Duration(milliseconds: newValue ? 25 : 150), () {
+      _testIsVisible = newValue;
 
-    // Don't report the same value multiple times
-    if (newValue == _isVisible) {
-      return;
-    }
+      // Don't report the same value multiple times
+      if (newValue == _isVisible) {
+        return;
+      }
 
-    _isVisible = newValue;
-    _onChangeController.add(newValue);
+      _isVisible = newValue;
+      _onChangeController.add(newValue);
+    });
   }
 }


### PR DESCRIPTION
I was using a forked version of flutter_keyboard_visibility that had detection for iOS floating keyboards on iPads.  I had also submitted a PR a few months ago to the main repo - but as you already know - no updates from them.