### PR TITLE
Adjust keyboard detection on Android

### DIFF
--- a/flutter_keyboard_visibility_temp_fork/android/src/main/java/com/jrai/flutter_keyboard_visibility_temp_fork/FlutterKeyboardVisibilityTempForkPlugin.java
+++ b/flutter_keyboard_visibility_temp_fork/android/src/main/java/com/jrai/flutter_keyboard_visibility_temp_fork/FlutterKeyboardVisibilityTempForkPlugin.java
@@ -69,9 +69,9 @@ public class FlutterKeyboardVisibilityTempForkPlugin implements FlutterPlugin, A
       Rect r = new Rect();
       mainView.getWindowVisibleDisplayFrame(r);
 
-      // check if the visible part of the screen is less than 85%
+      // check if the visible part of the screen is less than 82%
       // if it is then the keyboard is showing
-      boolean newState = ((double)r.height() / (double)mainView.getRootView().getHeight()) < 0.85;
+      boolean newState = ((double)r.height() / (double)mainView.getRootView().getHeight()) < 0.82;
 
       if (newState != isVisible) {
         isVisible = newState;


### PR DESCRIPTION
The ratio used in android keyboard check was 85%.  i.e. if less than 85% of the screen is available, assume the keyboard is up.  

On the Pixel 9 Pro, only 82.2% of the screen is available in landscape mode with normal status bar and gesture bar on the bottom.  This PR adjusts the check ratio from 85% to 82% so landscape on Pixel 9 Pro isn't incorrectly flagged as keyboard visible.