### PR TITLE
Use flutter.compileSdkVersion instead of pinning compileSdkVersion 34

### DIFF
--- a/flutter_keyboard_visibility_temp_fork/android/build.gradle
+++ b/flutter_keyboard_visibility_temp_fork/android/build.gradle
@@ -27,7 +27,7 @@ android {
         namespace 'com.jrai.flutter_keyboard_visibility_temp_fork'
     }
 
-    compileSdkVersion 34
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
## What

Replaces the hardcoded `compileSdkVersion 34` in the Android plugin build with `compileSdk = flutter.compileSdkVersion`, so the plugin always compiles against the SDK version of the consuming app's Flutter toolchain.

## Why

Newer Flutter/AGP toolchains require plugins to compile against newer API levels (e.g. on Flutter 3.44 / AGP 9, `flutter_plugin_android_lifecycle` requires consumers to compile against API 36). With the pin at 34, consumers have to add a Gradle workaround in their root build.gradle that force-overrides this plugin's compileSdk.

Tracking `flutter.compileSdkVersion` is the pattern used by the first-party flutter/packages plugins (`flutter_plugin_android_lifecycle`, `image_picker_android`, `shared_preferences_android`, ...) as well as the plus plugins (`device_info_plus`, `package_info_plus`, ...).

## Note

This relies on the Flutter Gradle tooling exposing the `flutter` extension to plugin projects, which requires a reasonably recent Flutter SDK — the same requirement the first-party plugins above already have, and flutter_quill (the main consumer of this package) already requires a recent Flutter.